### PR TITLE
hotfix : updated module name for the blinkit usecase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/defensestation/osquery/v2
+module github.com/grofers/osquery/v2
 
 go 1.22.1
 


### PR DESCRIPTION
We're using this library as a package. Currently, the module name defined in go.mod is `github.com/defensestation/osquery/v2` which is the source module package name. 
When doing go get `github.com/grofers/osquery/v2` it is giving error since the module name inside is different.

Changes -
Renamed the mdoule to `github.com/grofers/osquery/v2` to make it usable as a package separately.