### PR TITLE
SRCH-2643 | extends support for 'sort' clause having mode, nested_path, nested_filter

### DIFF
--- a/common.go
+++ b/common.go
@@ -23,8 +23,8 @@ func (source Source) Map() map[string]interface{} {
 	return m
 }
 
-// Sort represents a list of keys to sort by.
-type Sort []map[string]interface{}
+// Sort represents a list of SortParams for sorting purpose.
+type Sort []SortParams
 
 // Order is the ordering for a sort key (ascending, descending).
 type Order string
@@ -36,3 +36,50 @@ const (
 	// OrderDesc represents sorting in descending order.
 	OrderDesc Order = "desc"
 )
+
+// Mode is the mode for a sort key (min, max, sum, avg, median).
+type Mode string
+
+const (
+	// SortModeMin represents the minimum value.
+	SortModeMin Mode = "min"
+
+	// SortModeMax represents the maximum value.
+	SortModeMax Mode = "max"
+
+	// SortModeSum represents the sum of values.
+	SortModeSum Mode = "sum"
+
+	// SortModeAvg represents the average of values.
+	SortModeAvg Mode = "avg"
+
+	// SortModeMedian represents the median of values.
+	SortModeMedian Mode = "median"
+)
+
+type SortParams struct {
+	Field        string
+	Order        Order
+	Mode         Mode
+	NestedPath   string
+	NestedFilter Mappable
+}
+
+func (s SortParams) Map() map[string]interface{} {
+	sortOptions := map[string]interface{}{
+		"order": s.Order,
+	}
+	if s.Mode != "" {
+		sortOptions["mode"] = s.Mode
+	}
+	if s.NestedPath != "" {
+		sortOptions["nested_path"] = s.NestedPath
+
+		if s.NestedFilter != nil {
+			sortOptions["nested_filter"] = s.NestedFilter.Map()
+		}
+	}
+	return map[string]interface{}{
+		s.Field: sortOptions,
+	}
+}

--- a/search.go
+++ b/search.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	opensearch "github.com/opensearch-project/opensearch-go/v4"
-	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
 // SearchRequest represents the parameters for an OpenSearch query.
@@ -64,13 +64,8 @@ func (req *SearchRequest) Size(size uint64) *SearchRequest {
 }
 
 // Sort sets how the results should be sorted.
-func (req *SearchRequest) Sort(name string, order Order) *SearchRequest {
-	req.sort = append(req.sort, map[string]interface{}{
-		name: map[string]interface{}{
-			"order": order,
-		},
-	})
-
+func (req *SearchRequest) Sort(params SortParams) *SearchRequest {
+	req.sort = append(req.sort, params)
 	return req
 }
 
@@ -136,7 +131,11 @@ func (req *SearchRequest) Map() map[string]interface{} {
 		m["size"] = *req.size
 	}
 	if len(req.sort) > 0 {
-		m["sort"] = req.sort
+		sortMaps := make([]map[string]interface{}, 0, len(req.sort))
+		for _, params := range req.sort {
+			sortMaps = append(sortMaps, params.Map())
+		}
+		m["sort"] = sortMaps
 	}
 	if req.from != nil {
 		m["from"] = *req.from

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,8 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort("field_1", OrderDesc).
-				Sort("field_2", OrderAsc).
+				Sort(SortParams{Field: "field_1", Order: OrderDesc}).
+				Sort(SortParams{Field: "field_2", Order: OrderAsc}).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,141 @@
+// Package osquery provides a query builder for OpenSearch.
+package osquery
+
+import (
+	"testing"
+)
+
+func TestSortExtensions(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"sort with basic order only",
+			Search().Sort(SortParams{Field: "field", Order: OrderAsc}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field": map[string]interface{}{
+							"order": "asc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode",
+			Search().Sort(SortParams{Field: "field", Order: OrderDesc, Mode: SortModeAvg}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field": map[string]interface{}{
+							"order": "desc",
+							"mode":  "avg",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path",
+			Search().Sort(SortParams{Field: "nested.field", Order: OrderAsc, NestedPath: "nested"}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "asc",
+							"nested_path": "nested",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path and nested_filter",
+			Search().Sort(SortParams{
+				Field:        "nested.field",
+				Order:        OrderAsc,
+				NestedPath:   "nested",
+				NestedFilter: Match("nested.type").Query("value"),
+			}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "asc",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode, nested_path and nested_filter",
+			Search().Sort(SortParams{
+				Field:        "nested.field",
+				Order:        OrderDesc,
+				Mode:         SortModeMax,
+				NestedPath:   "nested",
+				NestedFilter: Match("nested.type").Query("value"),
+			}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "desc",
+							"mode":        "max",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"multiple sorts with different options",
+			Search().
+				Sort(SortParams{Field: "field1", Order: OrderAsc}).
+				Sort(SortParams{
+					Field:        "nested.field",
+					Order:        OrderDesc,
+					Mode:         SortModeMin,
+					NestedPath:   "nested",
+					NestedFilter: Match("nested.type").Query("value"),
+				}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field1": map[string]interface{}{
+							"order": "asc",
+						},
+					},
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "desc",
+							"mode":        "min",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
JIRA Ticket https://zomato.atlassian.net/browse/SRCH-2643

## Key Changes
### Addition of `Mode` for Sorting

- Introduced a new `Mode` type for specifying sorting modes (`min`, `max`, `sum`, `avg`, `median`).
- Added constants for these sorting modes: `SortModeMin`, `SortModeMax`, `SortModeSum`, `SortModeAvg`, `SortModeMedian`.

### Refactor of `Sort` Method

Updated the `Sort` method in `SearchRequest` to use a new `SortParams` struct, which includes:
- `Name`: The name of the field to sort.
- `Order`: Sorting order (asc or desc).
- `Mode`: Sorting mode (optional).
- `NestedPath`: Path for nested fields (optional).
- `NestedFilter`: Filter for nested objects (optional).

### Testing Enhancements

- Added a new test file `sort_test.go` for comprehensive test coverage of sorting functionality, including:
    - Sorting with basic order.
    - Sorting with modes.
    - Sorting with nested paths and filters.
    - Combination of multiple sorts with different options.
 
- Updated the existing `search_test.go` to reflect changes in the `Sort` method.