### PR TITLE
fixes: empty sort order handling

### DIFF
--- a/common.go
+++ b/common.go
@@ -66,8 +66,10 @@ type SortParams struct {
 }
 
 func (s SortParams) Map() map[string]interface{} {
-	sortOptions := map[string]interface{}{
-		"order": s.Order,
+	sortOptions := map[string]interface{}{}
+
+	if s.Order != "" {
+		sortOptions["order"] = s.Order
 	}
 	if s.Mode != "" {
 		sortOptions["mode"] = s.Mode


### PR DESCRIPTION
If the `sort.order` is not being sent, it should avoid keep sort.order key as empty string - as it break at ES side and throws 400 request exception from ES.