### PR TITLE
fixes: duplicating sort clauses for every request

### DIFF
--- a/search.go
+++ b/search.go
@@ -64,8 +64,8 @@ func (req *SearchRequest) Size(size uint64) *SearchRequest {
 }
 
 // Sort sets how the results should be sorted.
-func (req *SearchRequest) Sort(params SortParams) *SearchRequest {
-	req.sort = append(req.sort, params)
+func (req *SearchRequest) Sort(params ...SortParams) *SearchRequest {
+	req.sort = params
 	return req
 }
 


### PR DESCRIPTION
For every new request, the osquery is basically accumulating new sort clauses with the older ones. This PR fixes the problem since for every new request, we only want calculated sort clauses.