### PR TITLE
feat: add support for function_score clause in osquery package

### DIFF
--- a/function_score.go
+++ b/function_score.go
@@ -1,0 +1,104 @@
+// Package osquery Modified by harshit98 on 2025-05-10
+// Changes: Added function score support
+package osquery
+
+type FunctionScoreQuery struct {
+	query     Mappable
+	functions []Function
+	boostMode string
+	scoreMode string
+	maxBoost  float32
+	minScore  float32
+	boost     float32
+}
+
+type Function interface {
+	Map() map[string]interface{}
+}
+
+type RandomScoreFunction struct {
+	seed  *int64
+	field string
+}
+
+type FieldValueFactorFunction struct {
+	field    string
+	factor   float32
+	modifier string
+	missing  float32
+}
+
+// Additional functions can be added as per usecase in future like:
+// - ScriptScoreFunction
+// - DecayFunction (with variants for geo, date, numeric)
+// - WeightFunction
+//
+// For ref: https://docs.opensearch.org/docs/latest/query-dsl/compound/function-score/
+
+func FunctionScore(query Mappable) *FunctionScoreQuery {
+	return &FunctionScoreQuery{query: query}
+}
+
+func (q *FunctionScoreQuery) AddFunction(f Function) *FunctionScoreQuery {
+	q.functions = append(q.functions, f)
+	return q
+}
+
+func (q *FunctionScoreQuery) BoostMode(mode string) *FunctionScoreQuery {
+	q.boostMode = mode
+	return q
+}
+
+func (q *FunctionScoreQuery) Map() map[string]interface{} {
+	m := make(map[string]interface{})
+
+	if q.query != nil {
+		m["query"] = q.query.Map()
+	}
+
+	if len(q.functions) > 0 {
+		funcs := make([]map[string]interface{}, len(q.functions))
+		for i, f := range q.functions {
+			funcs[i] = f.Map()
+		}
+		m["functions"] = funcs
+	}
+
+	if q.boostMode != "" {
+		m["boost_mode"] = q.boostMode
+	}
+
+	return map[string]interface{}{
+		"function_score": m,
+	}
+}
+
+func RandomScore() *RandomScoreFunction {
+	return &RandomScoreFunction{}
+}
+
+func (f *RandomScoreFunction) Seed(seed int64) *RandomScoreFunction {
+	f.seed = &seed
+	return f
+}
+
+func (f *RandomScoreFunction) Field(field string) *RandomScoreFunction {
+	f.field = field
+	return f
+}
+
+func (f *RandomScoreFunction) Map() map[string]interface{} {
+	m := make(map[string]interface{})
+
+	if f.seed != nil {
+		m["seed"] = *f.seed
+	}
+
+	if f.field != "" {
+		m["field"] = f.field
+	}
+
+	return map[string]interface{}{
+		"random_score": m,
+	}
+}

--- a/function_score.go
+++ b/function_score.go
@@ -39,7 +39,7 @@ func FunctionScore(query Mappable) *FunctionScoreQuery {
 	return &FunctionScoreQuery{query: query}
 }
 
-func (q *FunctionScoreQuery) AddFunction(f Function) *FunctionScoreQuery {
+func (q *FunctionScoreQuery) Function(f Function) *FunctionScoreQuery {
 	q.functions = append(q.functions, f)
 	return q
 }

--- a/function_score_test.go
+++ b/function_score_test.go
@@ -9,7 +9,7 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with random_score function",
 			FunctionScore(Term("user", "kimchy")).
-				AddFunction(RandomScore()),
+				Function(RandomScore()),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
 					"query": map[string]interface{}{
@@ -30,7 +30,7 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with random_score function and boost_mode",
 			FunctionScore(Term("user", "kimchy")).
-				AddFunction(RandomScore()).
+				Function(RandomScore()).
 				BoostMode("sum"),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
@@ -53,7 +53,7 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with random_score function with seed",
 			FunctionScore(Term("user", "kimchy")).
-				AddFunction(RandomScore().Seed(42)),
+				Function(RandomScore().Seed(42)),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
 					"query": map[string]interface{}{
@@ -76,7 +76,7 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with random_score function with field",
 			FunctionScore(Term("user", "kimchy")).
-				AddFunction(RandomScore().Field("_seq_no")),
+				Function(RandomScore().Field("_seq_no")),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
 					"query": map[string]interface{}{
@@ -99,8 +99,8 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with multiple functions",
 			FunctionScore(Term("user", "kimchy")).
-				AddFunction(RandomScore()).
-				AddFunction(RandomScore().Seed(123)),
+				Function(RandomScore()).
+				Function(RandomScore().Seed(123)),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
 					"query": map[string]interface{}{
@@ -126,7 +126,7 @@ func TestFunctionScore(t *testing.T) {
 		{
 			"function_score query with match_all query",
 			FunctionScore(MatchAll()).
-				AddFunction(RandomScore()),
+				Function(RandomScore()),
 			map[string]interface{}{
 				"function_score": map[string]interface{}{
 					"query": map[string]interface{}{
@@ -149,7 +149,7 @@ func TestFunctionScoreWithQuery(t *testing.T) {
 			"query with function_score",
 			Query(
 				FunctionScore(Term("user", "kimchy")).
-					AddFunction(RandomScore()).
+					Function(RandomScore()).
 					BoostMode("sum"),
 			),
 			map[string]interface{}{

--- a/function_score_test.go
+++ b/function_score_test.go
@@ -1,0 +1,176 @@
+package osquery
+
+import (
+	"testing"
+)
+
+func TestFunctionScore(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"function_score query with random_score function",
+			FunctionScore(Term("user", "kimchy")).
+				AddFunction(RandomScore()),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with random_score function and boost_mode",
+			FunctionScore(Term("user", "kimchy")).
+				AddFunction(RandomScore()).
+				BoostMode("sum"),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+					"boost_mode": "sum",
+				},
+			},
+		},
+		{
+			"function_score query with random_score function with seed",
+			FunctionScore(Term("user", "kimchy")).
+				AddFunction(RandomScore().Seed(42)),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{
+								"seed": int64(42),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with random_score function with field",
+			FunctionScore(Term("user", "kimchy")).
+				AddFunction(RandomScore().Field("_seq_no")),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{
+								"field": "_seq_no",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with multiple functions",
+			FunctionScore(Term("user", "kimchy")).
+				AddFunction(RandomScore()).
+				AddFunction(RandomScore().Seed(123)),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+						{
+							"random_score": map[string]interface{}{
+								"seed": int64(123),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with match_all query",
+			FunctionScore(MatchAll()).
+				AddFunction(RandomScore()),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"match_all": map[string]interface{}{},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestFunctionScoreWithQuery(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"query with function_score",
+			Query(
+				FunctionScore(Term("user", "kimchy")).
+					AddFunction(RandomScore()).
+					BoostMode("sum"),
+			),
+			map[string]interface{}{
+				"query": map[string]interface{}{
+					"function_score": map[string]interface{}{
+						"query": map[string]interface{}{
+							"term": map[string]interface{}{
+								"user": map[string]interface{}{
+									"value": "kimchy",
+								},
+							},
+						},
+						"functions": []map[string]interface{}{
+							{
+								"random_score": map[string]interface{}{},
+							},
+						},
+						"boost_mode": "sum",
+					},
+				},
+			},
+		},
+	})
+}

--- a/function_score_test.go
+++ b/function_score_test.go
@@ -140,6 +140,63 @@ func TestFunctionScore(t *testing.T) {
 				},
 			},
 		},
+		{
+			"function_score query with script_score function",
+			FunctionScore(Term("user", "kimchy")).
+				Function(FunctionScriptScore(Script("my_script").Source("doc['my_field'].value * 2.0"))),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"script_score": map[string]interface{}{
+								"script": map[string]interface{}{
+									"source": "doc['my_field'].value * 2.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with script_score function with params",
+			FunctionScore(Term("user", "kimchy")).
+				Function(FunctionScriptScore(Script("my_script").
+					Source("doc['my_field'].value * params.factor").
+					Params(ScriptParams{"factor": 2.0}).
+					Lang("painless"))),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"script_score": map[string]interface{}{
+								"script": map[string]interface{}{
+									"source": "doc['my_field'].value * params.factor",
+									"params": map[string]interface{}{
+										"factor": 2.0,
+									},
+									"lang": "painless",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/query_nested.go
+++ b/query_nested.go
@@ -1,4 +1,4 @@
-// Modified by bforbhartiii on 2025-02-24
+// Package osquery Modified by bforbhartiii on 2025-02-24
 // Changes: Added nested query support
 package osquery
 
@@ -7,19 +7,19 @@ import "github.com/fatih/structs"
 type ScoreModeType string
 
 const (
-	// Uses the average relevance score of all matching inner documents
+	// ScoreModeAvg Uses the average relevance score of all matching inner documents
 	ScoreModeAvg ScoreModeType = "avg"
 
-	// Assigns the highest relevance score from the matching inner documents to the parent.
+	// ScoreModeMax Assigns the highest relevance score from the matching inner documents to the parent.
 	ScoreModeMax ScoreModeType = "max"
 
-	// Assigns the lowest relevance score from the matching inner documents to the parent.
+	// ScoreModeMin Assigns the lowest relevance score from the matching inner documents to the parent.
 	ScoreModeMin ScoreModeType = "min"
 
-	// Sums the relevance scores of all matching inner documents.
+	// ScoreModeSum Sums the relevance scores of all matching inner documents.
 	ScoreModeSum ScoreModeType = "sum"
 
-	// Ignores the relevance scores of inner documents and assigns a score of 0 to the parent document.
+	// ScoreModeNone Ignores the relevance scores of inner documents and assigns a score of 0 to the parent document.
 	ScoreModeNone ScoreModeType = "none"
 )
 

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,4 +1,5 @@
-// Package osquery provides a query builder for OpenSearch.
+// Package osquery Modified by harshit98 on 2025-05-07
+// Changes: Added sort params support like mode, nested_path, nested_filter
 package osquery
 
 import (


### PR DESCRIPTION
## Key Changes

### Function Score Support

- Added a new file `function_score.go` to implement function score queries.
- Introduced the `FunctionScoreQuery` struct and relevant methods:
    - FunctionScore(): Initializes a function score query.
    - AddFunction(Function): Adds scoring functions like RandomScore.
    - BoostMode(mode): Configures boosting mode.
    - Map(): Maps the function score query to a structured format.
- Added support for scoring functions:
    - RandomScoreFunction: Supports random scoring with optional `seed` and `field` parameters.
    - Additional scoring functions like `FieldValueFactorFunction` outlined for future use.

### Unit Tests for Function Score

- Added the `function_score_test.go` file.
- Added test cases for different `function_score` scenarios:

### Basic Function Score Queries
- Queries with boost modes, multiple functions, and seeds.
- Queries with `match_all` and `term` queries.

### Updated Documentation:

- Updated comments in `query_nested.go` to reflect proper struct and constant descriptions for ScoreModeType.
Sorting Parameters Support:
- Updated `sort_test.go` to support advanced sorting parameters like `mode`, `nested_path`, and `nested_filter`.

### References
For more details on the `function_score` query, see: [OpenSearch Documentation: Function Score Query](https://docs.opensearch.org/docs/latest/query-dsl/compound/function-score/)

### Testing
Unit tests have been added.