### PR TITLE
refactor: fixes sort function chaining and refactoring

### DIFF
--- a/search.go
+++ b/search.go
@@ -72,12 +72,6 @@ func (req *SearchRequest) Sort(opts ...SortOption) *SearchRequest {
 	return req
 }
 
-// SortScript is a convenience method for script-based sorting
-func (req *SearchRequest) SortScript(params ScriptSortParams) *SearchRequest {
-	req.sort = append(req.sort, &params)
-	return req
-}
-
 // SearchAfter retrieve the sorted result
 func (req *SearchRequest) SearchAfter(s ...interface{}) *SearchRequest {
 	req.searchAfter = append(req.searchAfter, s...)

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,10 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort(Field("field_1").Order(OrderDesc)).
-				Sort(Field("field_2").Order(OrderAsc)).
+				Sort(
+					FieldSort("field_1").Order(OrderDesc),
+					FieldSort("field_2").Order(OrderAsc),
+				).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/sort.go
+++ b/sort.go
@@ -36,8 +36,8 @@ type SortOption interface {
 	Map() map[string]any
 }
 
-// ScriptSortParams represents a script-based sort option for elasticsearch
-type ScriptSortParams struct {
+// ScriptSortOption represents a script-based sort option for elasticsearch
+type ScriptSortOption struct {
 	sortType string
 	script   *ScriptField
 	order    Order
@@ -45,19 +45,19 @@ type ScriptSortParams struct {
 
 // ScriptSort creates a new query of type "_script" with the provided
 // type and script.
-func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortParams {
-	return &ScriptSortParams{
+func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortOption {
+	return &ScriptSortOption{
 		script:   scriptField,
 		sortType: sortType,
 	}
 }
 
-func (s *ScriptSortParams) Order(order Order) *ScriptSortParams {
+func (s *ScriptSortOption) Order(order Order) *ScriptSortOption {
 	s.order = order
 	return s
 }
 
-func (s *ScriptSortParams) Map() map[string]any {
+func (s *ScriptSortOption) Map() map[string]any {
 	scriptMapRaw, ok := s.script.Map()["script"]
 	if !ok {
 		return nil
@@ -82,7 +82,7 @@ func (s *ScriptSortParams) Map() map[string]any {
 	}
 }
 
-type SortParams struct {
+type FieldSortOption struct {
 	field        string
 	order        Order
 	mode         Mode
@@ -90,49 +90,52 @@ type SortParams struct {
 	nestedFilter Mappable
 }
 
-func Field(field string) *SortParams {
-	return &SortParams{
+func FieldSort(field string) *FieldSortOption {
+	return &FieldSortOption{
 		field: field,
 	}
 }
 
-func (s *SortParams) Order(order Order) *SortParams {
-	s.order = order
-	return s
+func (f *FieldSortOption) Order(order Order) *FieldSortOption {
+	f.order = order
+	return f
 }
 
-func (s *SortParams) Mode(mode Mode) *SortParams {
-	s.mode = mode
-	return s
+func (f *FieldSortOption) Mode(mode Mode) *FieldSortOption {
+	f.mode = mode
+	return f
 }
 
-func (s *SortParams) NestedPath(nestedPath string) *SortParams {
-	s.nestedPath = nestedPath
-	return s
+func (f *FieldSortOption) NestedPath(nestedPath string) *FieldSortOption {
+	f.nestedPath = nestedPath
+	return f
 }
 
-func (s *SortParams) NestedFilter(nestedFilter Mappable) *SortParams {
-	s.nestedFilter = nestedFilter
-	return s
+func (f *FieldSortOption) NestedFilter(nestedFilter Mappable) *FieldSortOption {
+	f.nestedFilter = nestedFilter
+	return f
 }
 
-func (s *SortParams) Map() map[string]any {
+func (f *FieldSortOption) Map() map[string]any {
 	sortOptions := map[string]any{}
 
-	if s.order != "" {
-		sortOptions["order"] = s.order
+	if f.order != "" {
+		sortOptions["order"] = f.order
 	}
-	if s.mode != "" {
-		sortOptions["mode"] = s.mode
-	}
-	if s.nestedPath != "" {
-		sortOptions["nested_path"] = s.nestedPath
 
-		if s.nestedFilter != nil {
-			sortOptions["nested_filter"] = s.nestedFilter.Map()
+	if f.mode != "" {
+		sortOptions["mode"] = f.mode
+	}
+
+	if f.nestedPath != "" {
+		sortOptions["nested_path"] = f.nestedPath
+
+		if f.nestedFilter != nil {
+			sortOptions["nested_filter"] = f.nestedFilter.Map()
 		}
 	}
+
 	return map[string]any{
-		s.field: sortOptions,
+		f.field: sortOptions,
 	}
 }


### PR DESCRIPTION
Improves how we can use `Sort` capability. 

Earlier there were two functions responsible for handling field based sorting and script based sorting. Now there is only one function - which will be used both.