### PR TITLE
added name in terms query

### DIFF
--- a/query_term_level.go
+++ b/query_term_level.go
@@ -448,6 +448,7 @@ type TermsQuery struct {
 	field  string
 	values []interface{}
 	boost  float32
+	name   string
 }
 
 // Terms creates a new query of type "terms" on the provided field, and
@@ -465,6 +466,12 @@ func (q *TermsQuery) Values(values ...interface{}) *TermsQuery {
 	return q
 }
 
+// Name sets the name for the query.
+func (q *TermsQuery) Name(name string) *TermsQuery {
+	q.name = name
+	return q
+}
+
 // Boost sets the boost value of the query.
 func (q *TermsQuery) Boost(b float32) *TermsQuery {
 	q.boost = b
@@ -477,6 +484,9 @@ func (q TermsQuery) Map() map[string]interface{} {
 	innerMap := map[string]interface{}{q.field: q.values}
 	if q.boost > 0 {
 		innerMap["boost"] = q.boost
+	}
+	if q.name != "" {
+		innerMap["_name"] = q.name
 	}
 
 	return map[string]interface{}{"terms": innerMap}

--- a/query_term_level_test.go
+++ b/query_term_level_test.go
@@ -141,6 +141,17 @@ func TestTermLevel(t *testing.T) {
 			},
 		},
 		{
+			"terms",
+			Terms("user").Values("bla", "pl").Boost(1.3).Name("test"),
+			map[string]interface{}{
+				"terms": map[string]interface{}{
+					"user":  []string{"bla", "pl"},
+					"boost": 1.3,
+					"_name": "test",
+				},
+			},
+		},
+		{
 			"terms_set",
 			TermsSet("programming_languages", "go", "rust", "COBOL").MinimumShouldMatchField("required_matches"),
 			map[string]interface{}{


### PR DESCRIPTION
This pull request adds support for naming `TermsQuery` queries, allowing users to assign a custom name to each query for easier identification and debugging. The implementation includes changes to the `TermsQuery` struct, a new setter method, updates to the query serialization, and an additional test case to verify the new functionality.

**Support for named queries:**

* Added a `name` field to the `TermsQuery` struct to store the query name.
* Implemented the `Name` setter method for `TermsQuery`, enabling users to assign a name to the query.

**Query serialization and testing:**

* Updated the `Map()` method to include the `_name` field in the serialized query if a name is set.
* Added a test case in `query_term_level_test.go` to verify that the name is correctly set and serialized in the query output.